### PR TITLE
feat(tutorial): complete step 5

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+node_modules/.cache

--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+root: build

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,5 @@
+---
+applications:
+  - name: carbon-tutorial-Ryan-Gordon1
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "react-scripts build",
     "ci-check": "yarn format:diff",
     "clean": "yarn cache clean && yarn install",
+    "deploy": "rm -rf ./build && yarn build && cf push -f manifest.yml",
     "eject": "react-scripts eject",
     "format": "prettier --write \"**/*.{js,md,scss}\"",
     "format:diff": "prettier --list-different \"**/*.{js,md,scss}\"",

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,8 +3,22 @@ $feature-flags: (
   grid-columns-16: true,
 );
 
-@import 'carbon-components/scss/globals/scss/styles.scss';
+// Feature flags
+$css--font-face: true;
+$css--plex: true;
 
+// Global styles
+@import 'carbon-components/scss/globals/scss/css--font-face';
+@import 'carbon-components/scss/globals/grid/grid';
+
+// Carbon components
+@import 'carbon-components/scss/components/breadcrumb/breadcrumb';
+@import 'carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/data-table/data-table';
+@import 'carbon-components/scss/components/link/link';
+@import 'carbon-components/scss/components/pagination/pagination';
+@import 'carbon-components/scss/components/tabs/tabs';
+@import 'carbon-components/scss/components/ui-shell/ui-shell';
 // Remove overrides once Carbon bugs are fixed upstream.
 
 /// The React <Content /> component uses the `main` element which IE11 doesn't recognize


### PR DESCRIPTION
Closes out the react carbon-tutorial. Step 5 included deploying the app using cloud foundry.

As a bit of feedback, include a note on the step 5 login that you may need to use a different API endpoint such as `https://api.eu-de.bluemix.net` or `https://api.eu-gb.bluemix.net`

Link to deployed app : carbon-tutorial-ryan-gordon1.eu-gb.mybluemix.net
{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
