### PR TITLE
Fix: README tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This tutorial will guide you in creating a React app with the [Carbon Design System](https://www.carbondesignsystem.com/). We’ll teach you the ins and outs of using Carbon components, while introducing web development best practices along the way.
 
-Get started by visiting the [tutorial instructions](https://www.carbondesignsystem.com/tutorial/overview/).
+Get started by visiting the [tutorial instructions](https://www.carbondesignsystem.com/tutorial/react/overview).
 
 ## Available Scripts
 


### PR DESCRIPTION
Link to Carbon React tutorial migrated when a Vue tutorial was added

#### Changelog

**Changed**

- updated README

