### PR TITLE
chore(test): add test to step 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       - run:
           name: Run ci checks
           command: yarn ci-check
+      - run:
+          name: Run tests
+          command: yarn test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,4 @@ workflows:
   version: 2
   main:
     jobs:
-      - test
+      - step-one

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import App from './App';
+import { shallow } from 'enzyme';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+describe('React Step 1 Tests', () => {
+  it('renders without crashing', () => {
+    shallow(<App />);
+  });
+
+  const wrapper = shallow(<App />);
+  it('contains a TutorialHeader', () => {
+    expect(wrapper.find('TutorialHeader').length).toBe(1);
+  });
 });


### PR DESCRIPTION
Adds in a basic test to Step 1 that will fail if  `<App />` does not contain a `<TutorialHeader />`. We can then add in a `mergify` config that will appropriately handle PR's based on the test status. 

#### Changelog

**New**
- Add command to run tests to CircleCI config 
- A simple test to check for the existence of `<TutorialHeader />`
