### PR TITLE
feat(tutorial): complete step 5

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,5 @@
+---
+applications:
+  - name: carbon-tutorial-un2582
+    memory: 64M
+    buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/carbon-design-system/carbon-tutorial/issues",
   "license": "Apache-2.0",
   "scripts": {
+    "deploy": "rm -rf ./build && yarn build && cf push -f manifest.yml",
     "build": "react-scripts build",
     "ci-check": "yarn format:diff",
     "clean": "yarn cache clean && yarn install",

--- a/src/.cfignore
+++ b/src/.cfignore
@@ -1,0 +1,6 @@
+node_modules/.cache
+
+*
+
+!Staticfile
+!build

--- a/src/Staticfile
+++ b/src/Staticfile
@@ -1,0 +1,1 @@
+root:build

--- a/src/index.scss
+++ b/src/index.scss
@@ -2,7 +2,22 @@ $feature-flags: (
   grid-columns-16: true,
 );
 
-@import 'carbon-components/scss/globals/scss/styles.scss';
+// Feature flags
+$css--font-face: true;
+$css--plex: true;
+
+// Global styles
+@import 'carbon-components/scss/globals/scss/css--font-face';
+@import 'carbon-components/scss/globals/grid/grid';
+
+// Carbon components
+@import 'carbon-components/scss/components/breadcrumb/breadcrumb';
+@import 'carbon-components/scss/components/button/button';
+@import 'carbon-components/scss/components/data-table/data-table';
+@import 'carbon-components/scss/components/link/link';
+@import 'carbon-components/scss/components/pagination/pagination';
+@import 'carbon-components/scss/components/tabs/tabs';
+@import 'carbon-components/scss/components/ui-shell/ui-shell';
 
 /// Remove overrides once Carbon bugs are fixed upstream.
 /// Need grid option to not add page gutters at large viewports, to also use when nesting grids


### PR DESCRIPTION
Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}


URL: https://carbon-tutorial-un2582.mybluemix.net/  While deploying to cloud, I was given a warning that nginx 1.19.x is no longer available in buildpack. the URL gives a 403 error and states nginx. I am not sure how to troubleshoot. I believe I followed the tutorial without a mistake.
